### PR TITLE
Increasing UDP receiver buffer.

### DIFF
--- a/protocol1/radio.go
+++ b/protocol1/radio.go
@@ -270,6 +270,8 @@ func (radio *Radio) Start() error {
 		if err != nil {
 			return fmt.Errorf("error opening UDP connection: %w", err)
 		}
+		// We expect a log of incoming traffic
+		radio.conn.SetReadBuffer(512 * 1024)
 	}
 	err = radio.sendMetisCommand(metisStop)
 	if err != nil {


### PR DESCRIPTION
I have noticed that when using HL2, some of the traffic gets lost, resulting in following SSTV issues for example:

![SSTV-240127-220251-14230](https://github.com/jancona/hpsdr/assets/3293202/3b80eba4-bf2f-4a27-a733-9abcc017699f)
![SSTV-240127-221643-14230](https://github.com/jancona/hpsdr/assets/3293202/3f142aa9-9682-4d97-88b1-819d1bae55db)
![SSTV-240127-130940-28680](https://github.com/jancona/hpsdr/assets/3293202/51cda7d0-0a54-41b7-b7ac-cf5280c2266f)

I can think of at least three possible spots where data loss may happen:

1) Physical Ethernet link between HL2 and its host.
2) Incoming UDP buffer at the host, where hpsdr reads data from.
3) Ring buffers connecting CSDR components in OpenWebRX.

The present pull request tries to remedy item 2 above, by increasing incoming UDP buffer to 512kB. The actual buffer size may end up shorter than that, depending on the OS settings, but bigger than the default value of 200kB.
